### PR TITLE
task/PP-17388: Remove Language Handling on Redirect Generation - Prestashop

### DIFF
--- a/payrexx/composer.json
+++ b/payrexx/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^8",
-    "payrexx/payrexx": "^2.0.2"
+    "payrexx/payrexx": "^2.0.4"
   },
   "autoload": {
     "psr-4": {

--- a/payrexx/config.xml
+++ b/payrexx/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>payrexx</name>
     <displayName><![CDATA[Payrexx]]></displayName>
-    <version><![CDATA[1.6.3]]></version>
+    <version><![CDATA[1.6.4]]></version>
     <description><![CDATA[Accept payments using Payrexx Payment gateway]]></description>
     <author><![CDATA[Payrexx]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/payrexx/controllers/front/payrexx.php
+++ b/payrexx/controllers/front/payrexx.php
@@ -80,6 +80,11 @@ class PayrexxPayrexxModuleFrontController extends ModuleFrontController
                 $metaData['X-Plugin-Version'] = (string) $module->version;
             }
 
+            $lang = Language::getIsoById($context->cookie->id_lang);
+            if (!in_array($lang, $this->supportedLang)) {
+                $lang = $this->defaultLang;
+            }
+
             $gateway = $payrexxApiService->createPayrexxGateway(
                 $total,
                 $currencyIsoCode,
@@ -89,7 +94,8 @@ class PayrexxPayrexxModuleFrontController extends ModuleFrontController
                 $billingAddress,
                 $shippingAddress,
                 $pm,
-                $metaData
+                $metaData,
+                $lang
             );
 
             if (!$gateway) {
@@ -101,16 +107,7 @@ class PayrexxPayrexxModuleFrontController extends ModuleFrontController
                 $gateway->getId(),
                 $paymentMethod
             );
-            $lang = Language::getIsoById($context->cookie->id_lang);
-
-            if (!in_array($lang, $this->supportedLang)) {
-                $lang = $this->defaultLang;
-            }
-
-            $link = $gateway->getLink();
-            $gatewayUrl = str_replace('?', $lang . '/?', $link);
-
-            Tools::redirect($gatewayUrl);
+            Tools::redirect($gateway->getLink());
         } catch (PayrexxException $e) {
             Tools::redirect(
                 Context::getContext()->link->getModuleLink(

--- a/payrexx/payrexx.php
+++ b/payrexx/payrexx.php
@@ -31,7 +31,7 @@ class Payrexx extends PaymentModule
         $this->name = 'payrexx';
         $this->tab = 'payments_gateways';
         $this->module_key = '0c4dbfccbd85dd948fd9a13d5a4add90';
-        $this->version = '1.6.3';
+        $this->version = '1.6.4';
         $this->author = 'Payrexx';
         $this->is_eu_compatible = 1;
         $this->ps_versions_compliancy = ['min' => '8.0'];

--- a/payrexx/src/Service/PayrexxApiService.php
+++ b/payrexx/src/Service/PayrexxApiService.php
@@ -105,7 +105,8 @@ class PayrexxApiService
         array $billingAddress,
         array $shippingAddress,
         array $pm,
-        array $metaData
+        array $metaData,
+        string $lang
     ): ?Gateway {
         $basket = BasketUtil::createBasketByCart($cart);
         $basketAmount = BasketUtil::getBasketAmount($basket);
@@ -156,6 +157,10 @@ class PayrexxApiService
         $gateway->addField('delivery_postcode', $shippingAddress['postcode']);
         $gateway->addField('delivery_place', $shippingAddress['city']);
         $gateway->addField('delivery_country', $shippingAddress['country']);
+
+        if (!empty($lang)) {
+            $gateway->setLanguage($lang);
+        }
 
         try {
             $payrexx->setHttpHeaders($metaData);

--- a/payrexx/vendor/composer/installed.json
+++ b/payrexx/vendor/composer/installed.json
@@ -2,17 +2,17 @@
     "packages": [
         {
             "name": "payrexx/payrexx",
-            "version": "v2.0.2",
-            "version_normalized": "2.0.2.0",
+            "version": "v2.0.4",
+            "version_normalized": "2.0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/payrexx/payrexx-php.git",
-                "reference": "88ebd2d02e1809fff7b5fa93b4a66e3ac0186e9b"
+                "reference": "67baaba41165dee046087f8655da006e300c0cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/payrexx/payrexx-php/zipball/88ebd2d02e1809fff7b5fa93b4a66e3ac0186e9b",
-                "reference": "88ebd2d02e1809fff7b5fa93b4a66e3ac0186e9b",
+                "url": "https://api.github.com/repos/payrexx/payrexx-php/zipball/67baaba41165dee046087f8655da006e300c0cca",
+                "reference": "67baaba41165dee046087f8655da006e300c0cca",
                 "shasum": ""
             },
             "require": {
@@ -23,7 +23,7 @@
                 "pestphp/pest": "^3.8",
                 "phpstan/phpstan": "^1.9"
             },
-            "time": "2025-07-14T09:31:51+00:00",
+            "time": "2025-11-14T05:00:43+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -49,7 +49,7 @@
             ],
             "support": {
                 "issues": "https://github.com/payrexx/payrexx-php/issues",
-                "source": "https://github.com/payrexx/payrexx-php/tree/v2.0.2"
+                "source": "https://github.com/payrexx/payrexx-php/tree/v2.0.4"
             },
             "install-path": "../payrexx/payrexx"
         }

--- a/payrexx/vendor/composer/installed.php
+++ b/payrexx/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'payrexx/payrexxpaymentgateway',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => 'b80175e1d8d7e5036b6f534349df695c2e921f41',
+        'reference' => '609bb6b578718d09d65acc7083b0e58ef84ba089',
         'type' => 'prestashop-module',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,9 +11,9 @@
     ),
     'versions' => array(
         'payrexx/payrexx' => array(
-            'pretty_version' => 'v2.0.2',
-            'version' => '2.0.2.0',
-            'reference' => '88ebd2d02e1809fff7b5fa93b4a66e3ac0186e9b',
+            'pretty_version' => 'v2.0.4',
+            'version' => '2.0.4.0',
+            'reference' => '67baaba41165dee046087f8655da006e300c0cca',
             'type' => 'library',
             'install_path' => __DIR__ . '/../payrexx/payrexx',
             'aliases' => array(),
@@ -22,7 +22,7 @@
         'payrexx/payrexxpaymentgateway' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => 'b80175e1d8d7e5036b6f534349df695c2e921f41',
+            'reference' => '609bb6b578718d09d65acc7083b0e58ef84ba089',
             'type' => 'prestashop-module',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Communicator.php
+++ b/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Communicator.php
@@ -21,7 +21,7 @@ use Payrexx\Models\Request\PaymentMethod;
  */
 class Communicator
 {
-    public const VERSIONS = [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11];
+    public const VERSIONS = [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14];
     public const API_URL_FORMAT = 'https://api.%s/%s/%s/%s/%s';
     public const API_URL_BASE_DOMAIN = 'payrexx.com';
     public const DEFAULT_COMMUNICATION_HANDLER = '\Payrexx\CommunicationAdapter\CurlCommunication';

--- a/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Models/Request/Gateway.php
+++ b/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Models/Request/Gateway.php
@@ -71,6 +71,9 @@ class Gateway extends Base
     /** optional */
     protected bool $chargeOnAuthorization;
 
+    /** optional */
+    protected bool $reserveOnAuthorization;
+
     /** optional: Only for Clearhaus transactions. */
     protected string $customerStatementDescriptor;
 
@@ -115,6 +118,8 @@ class Gateway extends Base
 
     /** optional */
     protected string $spotlightOrderDetailsUrl;
+
+    protected string $language = '';
 
     public function getAmount(): int
     {
@@ -334,6 +339,16 @@ class Gateway extends Base
         $this->chargeOnAuthorization = $chargeOnAuthorization;
     }
 
+    public function isReserveOnAuthorization(): bool
+    {
+        return $this->reserveOnAuthorization;
+    }
+
+    public function setReserveOnAuthorization(bool $reserveOnAuthorization): void
+    {
+        $this->reserveOnAuthorization = $reserveOnAuthorization;
+    }
+
     public function getCustomerStatementDescriptor(): string
     {
         return $this->customerStatementDescriptor;
@@ -527,6 +542,16 @@ class Gateway extends Base
     public function setSpotlightOrderDetailsUrl(string $spotlightOrderDetailsUrl): void
     {
         $this->spotlightOrderDetailsUrl = $spotlightOrderDetailsUrl;
+    }
+
+    public function setLanguage(string $language): void
+    {
+        $this->language = $language;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
     }
 
     public function getResponseModel(): ResponseGateway

--- a/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Models/Response/Gateway.php
+++ b/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Models/Response/Gateway.php
@@ -52,6 +52,10 @@ class Gateway extends \Payrexx\Models\Request\Gateway
 
     public function setLink(string $link): void
     {
+        $language = $this->getLanguage();
+        if (!empty($language) && strpos($link, "/{$language}/") === false) {
+            $link = str_replace('/?', "/{$language}/?", $link);
+        }
         $this->link = $link;
     }
 

--- a/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Payrexx.php
+++ b/payrexx/vendor/payrexx/payrexx/lib/Payrexx/Payrexx.php
@@ -19,7 +19,7 @@ use Payrexx\Models\Base;
  */
 class Payrexx
 {
-    public const CLIENT_VERSION = '2.0.2';
+    public const CLIENT_VERSION = '2.0.4';
 
     protected Communicator $communicator;
 


### PR DESCRIPTION
**Test case:**

- Go to frontend.
- Selected the language as de
- Checkout the product.
- Redirected into payment page with selected language.