### PR TITLE
bugfix/PP-18905: Wrap error messages in l() to make them translatable

### DIFF
--- a/payrexx/controllers/front/validation.php
+++ b/payrexx/controllers/front/validation.php
@@ -59,14 +59,14 @@ class PayrexxValidationModuleFrontController extends ModuleFrontController
     {
         switch ($payrexxError) {
             case self::ERROR_CONFIG:
-                $errMsg = 'The connection to the payment provider failed. Please contact the Shop owner';
+                $errMsg = $this->module->l('The connection to the payment provider failed. Please contact the Shop owner');
                 break;
             case self::ERROR_CANCEL:
-                $errMsg = 'The transaction was cancelled. Please try again';
+                $errMsg = $this->module->l('The transaction was cancelled. Please try again');
                 break;
             case self::ERROR_FAIL:
             default:
-                $errMsg = 'The transaction failed. Please try again';
+                $errMsg = $this->module->l('The transaction failed. Please try again');
                 break;
         }
 


### PR DESCRIPTION
## Summary
- Wraps three hardcoded English error messages in `validation.php` with `$this->module->l()` so they can be translated via PrestaShop's module translation system
- Affected messages: payment provider connection failure, transaction cancelled, transaction failed

## Context
Jira: PP-18905 — A merchant requested that error messages in the Payrexx payment module be translatable. The strings were previously hardcoded in English with no way to localize them.
